### PR TITLE
Copy in strlcpy from libbsd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN dnf install -y  \
     arm-none-eabi-gcc-cs-c++ \
     arm-none-eabi-binutils-cs \
     arm-none-eabi-newlib \
-    libbsd-devel \
     cmake
 
 COPY docker_build.sh /build.sh

--- a/README.md
+++ b/README.md
@@ -144,11 +144,8 @@ Software requirements:
 
 On a Red Hat/Fedora Linux installation, the following packages can be installed:
 ```bash
-dnf install arm-none-eabi-gcc-cs arm-none-eabi-gcc-cs-c++ arm-none-eabi-binutils-cs arm-none-eabi-newlib libbsd-devel cmake openocd
+dnf install arm-none-eabi-gcc-cs arm-none-eabi-gcc-cs-c++ arm-none-eabi-binutils-cs arm-none-eabi-newlib cmake openocd
 ```
-
-Note that the code uses `strlcpy()` also in the test code, which requires `libbsd-dev` (Debian/Ubuntu) or
-`libbsd-devel` (Red Hat/Fedora) to be installed for compilation to succeed.
 
 ### Steps to build the firmware
 

--- a/src/radio.c
+++ b/src/radio.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "log.h"
+#include "strlcpy.h"
 #include "template.h"
 #include "hal/system.h"
 #include "hal/delay.h"

--- a/src/strlcpy.c
+++ b/src/strlcpy.c
@@ -1,0 +1,50 @@
+/*    $OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $    */
+
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+size_t
+strlcpy(char *dst, const char *src, size_t dsize)
+{
+    const char *osrc = src;
+    size_t nleft = dsize;
+
+    /* Copy as many bytes as will fit. */
+    if (nleft != 0) {
+        while (--nleft != 0) {
+            if ((*dst++ = *src++) == '\0')
+                break;
+        }
+    }
+
+    /* Not enough room in dst, add NUL and traverse rest of src. */
+    if (nleft == 0) {
+        if (dsize != 0)
+            *dst = '\0'; /* NUL-terminate dst */
+        while (*src++)
+            ;
+    }
+
+    return(src - osrc - 1); /* count does not include NUL */
+}

--- a/src/strlcpy.h
+++ b/src/strlcpy.h
@@ -1,0 +1,8 @@
+#ifndef __STRLCPY_H
+#define __STRLCPY_H
+
+#include <sys/types.h>
+
+size_t strlcpy(char *dst, const char *src, size_t siz);
+
+#endif

--- a/src/template.c
+++ b/src/template.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include "utils.h"
 #include "config.h"
+#include "strlcpy.h"
 #include "template.h"
 
 size_t template_replace(char *dest, size_t dest_len, char *src, telemetry_data *data)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,17 +7,15 @@ project(RS41ng_test C CXX)
 
 set(BINARY ${CMAKE_PROJECT_NAME})
 
-file(GLOB_RECURSE USER_SOURCES "../src/config.c" "../src/codecs/*.c" "../src/template.c" "../src/utils.c")
+file(GLOB_RECURSE USER_SOURCES "../src/config.c" "../src/codecs/*.c" "../src/template.c" "../src/utils.c" "../src/strlcpy.c")
 file(GLOB_RECURSE USER_SOURCES_CXX "../src/codecs/*.cpp")
-file(GLOB_RECURSE USER_HEADERS "../src/codecs/*.h" "../src/template.h" "../src/utils.h" "../src/config.h")
+file(GLOB_RECURSE USER_HEADERS "../src/codecs/*.h" "../src/template.h" "../src/utils.h" "../src/config.h" "../src/strlcpy.h")
 
 file(GLOB_RECURSE TEST_SOURCES "*.c")
 file(GLOB_RECURSE TEST_SOURCES_CXX "*.cpp")
 file(GLOB_RECURSE TEST_HEADERS "*.h")
 
 set(SOURCES ${TEST_SOURCES})
-
-set(CMAKE_EXE_LINKER_FLAGS "-lbsd")
 
 add_executable(${BINARY} ${TEST_SOURCES} ${USER_SOURCES})
 

--- a/tests/template_test.c
+++ b/tests/template_test.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-#include <bsd/string.h>
+#include "strlcpy.h"
 #include "template.h"
 
 int main(void)


### PR DESCRIPTION
While building on Ubuntu, I ran into several `undefined reference to strlcpy` errors. (The readme mentions that this might occur.)

Since RS41ng uses only a single function from libbsd, I think it would make sense to just pull in a copy of that function and avoid having a dependency on libbsd. I've done that here, and the project now builds without issue on Ubuntu.