### PR TITLE
Modified formula for voltage calculation on dfm17

### DIFF
--- a/src/hal/system.c
+++ b/src/hal/system.c
@@ -211,7 +211,14 @@ static void dma_adc_init()
 
 uint16_t system_get_battery_voltage_millivolts()
 {
+#ifdef RS41
     return (uint16_t) (((float) dma_buffer_adc[0]) * 10.0f * 600.0f / 4096.0f);
+#else  //DFM17
+    // Kludge:  DFM17 voltage is more than 5 volts, so cut the value in half.
+    // Changed 600 to 690 to try and get it more accurate to actual voltage
+    // 690 yields fairly linear, accurate results between 5v6 and 6v6
+    return (uint16_t) ( ((float) dma_buffer_adc[0]) * 10.0f * 690.0f / 8192.0f );
+#endif 
 }
 
 uint16_t system_get_button_adc_value()


### PR DESCRIPTION
Modified the formula for battery voltage on the DFM17.  Horus Binary only supports voltages up to 5v0.  So, we now divide the value by 2.  Also, I tweaked the multipliers a bit to provide a more accurate voltage between 5v6 and 6v6, which are likely to be the voltages seen in flight.