### PR TITLE
Adjustments to synchronize CATS transmit to GPS data rate.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -101,7 +101,8 @@ char *cats_comment_templates[] = {
 //    "$dc $gu $sv $lat $lon - $hh:$mm:$ss @ $tow ms",
 //    "T:$teC H:$hu% P:$prmb - " CATS_COMMENT,
 //    "T:$teC H:$hu% P:$prmb PC:$pc RI:$ri uR/h - " CATS_COMMENT,
-    CATS_COMMENT,
+    "$tow CLIMB:$cl - " CATS_COMMENT,
+//    CATS_COMMENT,
     NULL
 };
 

--- a/src/radio.c
+++ b/src/radio.c
@@ -933,13 +933,13 @@ bool radio_handle_time_sync()
         return false;
     }
 
-    uint32_t time_sync_offset_millis = radio_current_transmit_entry->time_sync_seconds_offset * 1000;
+    uint32_t time_sync_offset_millis = radio_current_transmit_entry->time_sync_seconds_offset;
 
     if (time_millis < time_sync_offset_millis) {
         return false;
     }
 
-    uint32_t time_sync_millis = radio_current_transmit_entry->time_sync_seconds * 1000;
+    uint32_t time_sync_millis = radio_current_transmit_entry->time_sync_seconds;
 
     uint32_t time_with_offset_millis = time_millis - time_sync_offset_millis;
     uint32_t time_sync_period_millis = time_with_offset_millis % time_sync_millis;


### PR DESCRIPTION
CATS transmit rate must match the GPS data rate when using the high 'less than one second gps data acquisition rates. 