### PR TITLE
Error codes + landed mode configurator support

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -9,9 +9,7 @@ name: Deploy web configurator
 
 on:
   push:
-    # TEMPORARY: web-configurator is included so Pages can be tested from the branch
-    # before merge. Revert to `branches: [main]` once verified.
-    branches: [main, web-configurator]
+    branches: [main]
     paths:
       - "web/**"
       - ".github/workflows/deploy-web.yml"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,11 +1,11 @@
-# Builds the web configurator (web/) and deploys it to GitHub Pages.
+# Builds the web firmware configurator (web/) and deploys it to GitHub Pages.
 #
 # One-time repo setup:
 #   Settings → Pages → Build and deployment → Source = "GitHub Actions".
 # The site is served at https://<owner>.github.io/<repo>/ — vite.config.ts uses
 # base "./" (relative paths) so it works from that subpath without further config.
 
-name: Deploy web configurator
+name: Deploy web firmware configurator
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /cmake-build-debug
 /cmake-build-debug-arm-none-eabi
 /build
+/build-tests
 /samples
 *~
 .vscode/

--- a/README.md
+++ b/README.md
@@ -655,6 +655,20 @@ use command `file src/RS41ng.elf`.
 
 NOTE: To save RAM, the heap size has been zeroed out. Dynamic memory allocations (`malloc`, etc.) will not function. Use static or stack-based allocation if needed.
 
+## Building and running unit tests
+
+```bash
+# Configure tests (defaults to -DRS41=1)
+cmake -S tests -B build-tests
+# Build all tests
+cmake --build build-tests
+# Run all tests
+ctest --test-dir build-tests --output-on-failure
+
+# Run a single test
+ctest --test-dir build-tests -R template_test --output-on-failure
+```
+
 ## Hardware-specific Notes
 
 This section is allocated for documentation of various features and oddities of specific radiosonde types.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -20,6 +20,7 @@
 #   $loc8  Locator (8 chars)
 #   $loc12  Locator (12 chars)
 #   $bv  Battery voltage in mV (up to 4 chars)
+#   $bu  Button ADC value (raw reading, up to 4 chars)
 #   $te  External temperature in C (up to 3 chars)
 #   $ti  Internal temperature in C (up to 3 chars)
 #   $hu  Humidity % (up to 3 chars)
@@ -38,7 +39,9 @@
 #   $pc  Pulse counter value (wraps to zero at 65535, 16-bit unsigned)
 #   $ri  Radiation intensity in uR/h (up to 5 chars)
 #   $dc  Data counter value (wraps to zero at 65535, 16-bit unsigned)
+#   $apc  APRS packet counter value (16-bit unsigned)
 #   $gu  GPS data update indicator (1 if updated, 0 otherwise)
+#   $err  System error code, zero-padded to 2 digits (see errors.h; 0 = no error)
 #   $ct  Clock calibration trim value (0-31, DFM-17 only)
 #   $cc  Clock calibration change count (DFM-17 only)
 
@@ -551,6 +554,9 @@ horus_v3:
   # Disable SondeHub Upload — Disable uploading telemetry to SondeHub [intermediate]
   #   defines HORUS_V3_NOHUB
   nohub: false
+  # Transmit Error Code — Transmit the system error code (see errors.h, also available as $err) as an "err" extra sensor field [intermediate]
+  #   defines HORUS_V3_TX_ERROR_CODE
+  error_code: false
   # Time Sync Interval (s) — Transmit every N seconds from top of hour. 0 = no time sync. [intermediate]
   #   constraints: range 0..3600
   #   defines HORUS_V3_TIME_SYNC_SECONDS
@@ -882,3 +888,64 @@ jt65:
   #   constraints: range 0..3600
   #   defines JT65_TIME_SYNC_OFFSET_SECONDS
   time_sync_offset_seconds: 1
+
+# ========================================================================
+# Landed Mode
+# ========================================================================
+landed:
+  # Enable Landed Mode — Enable battery conservation after the balloon has landed. [intermediate]
+  #   defines LANDED_MODE_ENABLE
+  enable: false
+  # Arm Altitude (m) — Altitude in meters that must be exceeded during ascent to arm landed mode. [advanced]
+  #   constraints: range 0..50000
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_ARM_ALTITUDE_METERS
+  arm_altitude_meters: 5000
+  # Climb Threshold (cm/s) — Maximum absolute vertical speed in cm/s to consider "stationary" (50 = 0.5 m/s). [advanced]
+  #   constraints: range 0..10000
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_CLIMB_THRESHOLD_CM_S
+  climb_threshold_cm_s: 50
+  # Speed Threshold (cm/s) — Maximum ground speed in cm/s to consider "stationary" (50 = 0.5 m/s). [advanced]
+  #   constraints: range 0..10000
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_SPEED_THRESHOLD_CM_S
+  speed_threshold_cm_s: 50
+  # Stationary Time (s) — Number of consecutive seconds the unit must be stationary before entering landed mode. [advanced]
+  #   constraints: range 0..86400
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_STATIONARY_SECONDS
+  stationary_seconds: 600
+  # Sleep Duration (s) — Sleep duration in seconds between wake-transmit cycles while in landed mode. [advanced]
+  #   constraints: range 0..86400
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_SLEEP_SECONDS
+  sleep_seconds: 300
+  # GPS Fix Timeout (s) — Maximum time in seconds to wait for GPS fix after waking before transmitting anyway. [advanced]
+  #   constraints: range 0..3600
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_GPS_FIX_TIMEOUT_SECONDS
+  gps_fix_timeout_seconds: 120
+  # Transmit Cycle Timeout (s) — Safety maximum time in seconds for the transmit cycle (normally the cycle completes on its own). [advanced]
+  #   constraints: range 0..3600
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_TRANSMIT_SECONDS
+  transmit_seconds: 30
+  # Geofence Radius (m) — Geofence radius in meters from the landing point. If the unit moves beyond this radius, landed mode is disabled (returns to armed). Set to 0 to disable the geofence. [advanced]
+  #   constraints: range 0..100000
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_GEOFENCE_RADIUS_METERS
+  geofence_radius_meters: 100
+  # Enable Pip While Sleeping — Emit a PIP at the configured interval while sleeping, without waking the GPS. Uses the existing PIP radio infrastructure (morse 'E' character). [advanced]
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_PIP_ENABLE
+  pip_enable: true
+  # Pip Interval (s) — Interval in seconds between pips while sleeping in landed mode. [advanced]
+  #   constraints: range 1..3600
+  #   applies when: landed.enable && landed.pip_enable
+  #   defines LANDED_MODE_PIP_INTERVAL_SECONDS
+  pip_interval_seconds: 10
+  # LEDs Only During Transmit — When true, LEDs are forced off during landed sleep/acquire states and only enabled during TRANSMITTING or PIPPING to conserve power. [advanced]
+  #   applies when: landed.enable
+  #   defines LANDED_MODE_LEDS_TRANSMIT_ONLY
+  leds_transmit_only: true

--- a/src/bme68x_handler.c
+++ b/src/bme68x_handler.c
@@ -161,18 +161,20 @@ bool bme68x_read_telemetry(telemetry_data *data)
     bool success;
 
     if (bme680_initialization_required) {
-        if(LEDS_ENABLE)
+        if (LEDS_ENABLE) {
             set_red_led(true);
+        }
 
-        log_info("BME re-init\n");
+        log_info("BME68X re-init\n");
         success = bme68x_handler_init();
-        log_info("BME re-init: %d\n", success);
+        log_info("BME68X re-init: %d\n", success);
         if (!success) {
             data->temperature_celsius_100 = 0;
             data->pressure_mbar_100 = 0;
             data->humidity_percentage_100 = 0;
             data->bme6xx_gas_r = 0;
             data->ext_sensor_type = NO_EXT_SENSOR;
+            set_error_code(ERROR_BME68X_READ);
             return false;
         } else if(LEDS_ENABLE) {
             set_red_led(false);
@@ -182,12 +184,13 @@ bool bme68x_read_telemetry(telemetry_data *data)
     success = bme68x_read(&data->temperature_celsius_100, &data->pressure_mbar_100, &data->humidity_percentage_100, &data->bme6xx_gas_r);
 
     if (!success) {
-        if(LEDS_ENABLE)
+        if (LEDS_ENABLE) {
             set_red_led(true);
+        }
 
-        log_info("BME re-init\n");
+        log_info("BME68X re-init\n");
         success = bme68x_handler_init();
-        log_info("BME re-init: %d\n", success);
+        log_info("BME68X re-init: %d\n", success);
 
         if (success) {
             success = bme68x_read(&data->temperature_celsius_100, &data->pressure_mbar_100, &data->humidity_percentage_100, &data->bme6xx_gas_r);
@@ -206,6 +209,9 @@ bool bme68x_read_telemetry(telemetry_data *data)
 
     if(success) {
         data->ext_sensor_type = SENSOR_BME68X;
+        clear_error_code(ERROR_BME68X_READ);
+    } else {
+        set_error_code(ERROR_BME68X_READ);
     }
 
     bme680_initialization_required = !success;

--- a/src/bme690_handler.c
+++ b/src/bme690_handler.c
@@ -152,18 +152,20 @@ bool bme690_read_telemetry(telemetry_data *data)
     bool success;
 
     if (bme690_initialization_required) {
-        if(LEDS_ENABLE)
+        if (LEDS_ENABLE) {
             set_red_led(true);
+        }
 
-        log_info("BME re-init\n");
+        log_info("BME690 re-init\n");
         success = bme690_handler_init();
-        log_info("BME re-init: %d\n", success);
+        log_info("BME690 re-init: %d\n", success);
         if (!success) {
             data->temperature_celsius_100 = 0;
             data->pressure_mbar_100 = 0;
             data->humidity_percentage_100 = 0;
             data->bme6xx_gas_r = 0;
             data->ext_sensor_type = NO_EXT_SENSOR;
+            set_error_code(ERROR_BME690_READ);
             return false;
         } else if(LEDS_ENABLE) {
             set_red_led(false);
@@ -173,12 +175,13 @@ bool bme690_read_telemetry(telemetry_data *data)
     success = bme690_read(&data->temperature_celsius_100, &data->pressure_mbar_100, &data->humidity_percentage_100, &data->bme6xx_gas_r);
 
     if (!success) {
-        if(LEDS_ENABLE)
+        if (LEDS_ENABLE) {
             set_red_led(true);
+        }
 
-        log_info("BME re-init\n");
+        log_info("BME690 re-init\n");
         success = bme690_handler_init();
-        log_info("BME re-init: %d\n", success);
+        log_info("BME690 re-init: %d\n", success);
 
         if (success) {
             success = bme690_read(&data->temperature_celsius_100, &data->pressure_mbar_100, &data->humidity_percentage_100, &data->bme6xx_gas_r);
@@ -197,6 +200,9 @@ bool bme690_read_telemetry(telemetry_data *data)
 
     if(success) {
         data->ext_sensor_type = SENSOR_BME690;
+        clear_error_code(ERROR_BME690_READ);
+    } else {
+        set_error_code(ERROR_BME690_READ);
     }
 
     bme690_initialization_required = !success;

--- a/src/bmp280_handler.c
+++ b/src/bmp280_handler.c
@@ -57,8 +57,9 @@ bool bmp280_read_telemetry(telemetry_data *data)
     bool success;
 
     if (bmp280_initialization_required) {
-        if(LEDS_ENABLE)
+        if (LEDS_ENABLE) {
             set_red_led(true);
+        }
 
         log_info("BMP280 re-init\n");
         success = bmp280_handler_init();
@@ -68,6 +69,7 @@ bool bmp280_read_telemetry(telemetry_data *data)
             data->pressure_mbar_100 = 0;
             data->humidity_percentage_100 = 0;
             data->ext_sensor_type = NO_EXT_SENSOR;
+            set_error_code(ERROR_BMP280_READ);
             return false;
         } else if(LEDS_ENABLE) {
             set_red_led(false);
@@ -77,8 +79,9 @@ bool bmp280_read_telemetry(telemetry_data *data)
     success = bmp280_read(&data->temperature_celsius_100, &data->pressure_mbar_100, &data->humidity_percentage_100);
 
     if (!success) {
-        if(LEDS_ENABLE)
+        if (LEDS_ENABLE) {
             set_red_led(true);
+        }
 
         log_info("BMP280 re-init\n");
         success = bmp280_handler_init();
@@ -100,6 +103,9 @@ bool bmp280_read_telemetry(telemetry_data *data)
 
     if(success) {
         data->ext_sensor_type = (bmp280_dev.id == BMP280_CHIP_ID) ? SENSOR_BMP280 : SENSOR_BME280;
+        clear_error_code(ERROR_BMP280_READ);
+    } else {
+        set_error_code(ERROR_BMP280_READ);
     }
 
     bmp280_initialization_required = !success;

--- a/src/codecs/horus/horus_packet_v3.c
+++ b/src/codecs/horus/horus_packet_v3.c
@@ -284,6 +284,31 @@ size_t horus_packet_v3_create(uint8_t *payload, telemetry_data *data){
     }
 #endif
 
+#if HORUS_V3_TX_ERROR_CODE
+    // Add the system error code (see errors.h) as an "err" extra sensor field
+    if (asnMessage.extraSensors.nCount < 4) {
+        asnMessage.exist.extraSensors = true;
+        horusAdditionalSensorType error_struct = {
+            .name = "err",
+            .exist = {
+                .name = 1,
+                .values = 1
+            },
+            .values = {
+                .kind = horusInt_PRESENT,
+                .u = {
+                    .horusInt = {
+                        .nCount = 1,
+                        .arr[0] = data->error_code
+                    }
+                }
+            }
+        };
+        asnMessage.extraSensors.arr[asnMessage.extraSensors.nCount] = error_struct;
+        asnMessage.extraSensors.nCount += 1;
+    }
+#endif
+
     memset(&encodedMessage, 0, sizeof(encodedMessage));
 
     // The Encoder may fail and update an error code
@@ -316,6 +341,7 @@ size_t horus_packet_v3_create(uint8_t *payload, telemetry_data *data){
             log_error("[error]: HORUS v3 Assert Failure, maybe hit buffer size limit\n");
         }
         // Need to check what happens here.
+        set_error_code(ERROR_HORUS_V3_ENCODE);
         return 0;
     } else {
         // Encoding was successful!
@@ -347,6 +373,7 @@ size_t horus_packet_v3_create(uint8_t *payload, telemetry_data *data){
                 log_error("[error]: HORUS v3 Extension Assert Failure, maybe hit buffer size limit\n");
             }
             // Need to check what happens here.
+            set_error_code(ERROR_HORUS_V3_EXT_ENCODE);
             return 0;
         }
 
@@ -377,6 +404,10 @@ size_t horus_packet_v3_create(uint8_t *payload, telemetry_data *data){
         memcpy(payload, &packetCrc, sizeof(packetCrc));  // little‑endian on STM32
 
         log_info("HORUS v3 ASN1: %i Frame: %i\n", encodedSize, frameSize);
+
+        // Encoding succeeded - clear any Horus encode error
+        clear_error_code(ERROR_HORUS_V3_ENCODE);
+        clear_error_code(ERROR_HORUS_V3_EXT_ENCODE);
 
         return frameSize;
     }

--- a/src/config.h
+++ b/src/config.h
@@ -304,6 +304,8 @@ Setting, measured RF output power, relative DC power draw
 #define HORUS_V3_PREAMBLE_LENGTH 4
 #define HORUS_V3_TONE_SPACING_HZ_SI5351 270
 #define HORUS_V3_NOHUB false // Disable uploading to SondeHub
+// Transmit the system error code (see errors.h, also available as $err) as an "err" extra sensor field
+#define HORUS_V3_TX_ERROR_CODE false
 
 // Schedule transmission every N seconds, counting from beginning of an hour (based on GPS time). Set to zero to disable time sync.
 // See the README file for more detailed documentation about time sync and its offset setting

--- a/src/config_internal.h
+++ b/src/config_internal.h
@@ -8,7 +8,12 @@
 
 #define RADIO_PAYLOAD_MAX_LENGTH 512
 #define RADIO_SYMBOL_DATA_MAX_LENGTH 256
+#ifdef RS41_RSM4x4
+// RSM4x4 has more space for the payload message
+#define RADIO_PAYLOAD_MESSAGE_MAX_LENGTH 128
+#else
 #define RADIO_PAYLOAD_MESSAGE_MAX_LENGTH 64
+#endif
 
 #define RADIO_APRS_PAYLOAD_MAX_LENGTH 192
 
@@ -35,6 +40,16 @@
 #define GPS_INIT_RED_LED_RETRY_THRESHOLD 3
 
 #include <stdbool.h>
+
+// System error codes and the set_error_code() / clear_error_code() API
+#include "errors.h"
+
+// Transmit the system error code in Horus v3 as an "err" extra sensor field.
+// Defaults to off here so generated configs (config_generated.h) that don't set
+// it still build; manual config.h overrides this.
+#ifndef HORUS_V3_TX_ERROR_CODE
+#define HORUS_V3_TX_ERROR_CODE 0
+#endif
 
 extern volatile bool system_initialized;
 

--- a/src/drivers/gps/ubxg6010/ubxg6010.c
+++ b/src/drivers/gps/ubxg6010/ubxg6010.c
@@ -523,6 +523,7 @@ bool ubxg6010_enable_power_save_mode()
     success = ubxg6010_wait_for_ack();
     if (!success) {
         log_error("GPS: Entering power-saving mode failed\n");
+        set_error_code(ERROR_GPS_POWER_SAVE);
     }
 
     return success;

--- a/src/drivers/gps/ubxm10050/ubxm10050.c
+++ b/src/drivers/gps/ubxm10050/ubxm10050.c
@@ -823,6 +823,7 @@ bool ubxm10050_enable_power_save_mode(void)
     log_info("GPS M10: OPERATEMODE=2: %s\n", success ? "ACK" : "NAK");
     if (!success) {
         log_error("GPS M10: Failed to enable PSMCT\n");
+        set_error_code(ERROR_GPS_POWER_SAVE);
         return false;
     }
 
@@ -904,6 +905,7 @@ bool ubxm10050_init(void)
                                        (uint32_t)GPS_SERIAL_PORT_BAUD_RATE);
         if (!success) {
             log_error("GPS M10: Failed to set baud rate\n");
+            set_error_code(ERROR_GPS_CONFIG);
             return false;
         }
         delay_ms(100);
@@ -929,6 +931,7 @@ bool ubxm10050_init(void)
                                              sizeof(proto_items) / sizeof(proto_items[0]));
         if (!success) {
             log_error("GPS M10: Protocol config failed\n");
+            set_error_code(ERROR_GPS_CONFIG);
             return false;
         }
     }
@@ -955,6 +958,7 @@ bool ubxm10050_init(void)
                                              sizeof(nav_items) / sizeof(nav_items[0]));
         if (!success) {
             log_error("GPS M10: Nav config failed\n");
+            set_error_code(ERROR_GPS_CONFIG);
             return false;
         }
     }
@@ -967,6 +971,7 @@ bool ubxm10050_init(void)
                                        GPS_MEASUREMENT_RATE);
         if (!success) {
             log_error("GPS M10: Measurement rate config failed\n");
+            set_error_code(ERROR_GPS_CONFIG);
             return false;
         }
     }
@@ -1034,6 +1039,7 @@ bool ubxm10050_init(void)
                                              sizeof(msg_items) / sizeof(msg_items[0]));
         if (!success) {
             log_error("GPS M10: Message rate config failed\n");
+            set_error_code(ERROR_GPS_CONFIG);
             return false;
         }
     }
@@ -1055,6 +1061,7 @@ bool ubxm10050_init(void)
                                              sizeof(nmea_items) / sizeof(nmea_items[0]));
         if (!success) {
             log_error("GPS M10: NMEA message rate config failed\n");
+            set_error_code(ERROR_GPS_CONFIG);
             return false;
         }
     }

--- a/src/drivers/hal/i2c.c
+++ b/src/drivers/hal/i2c.c
@@ -92,6 +92,7 @@ void i2c_init()
     }
     if (count == 0) {
         log_error("ERROR: I²C bus busy during initialization\n");
+        set_error_code(ERROR_I2C_BUS_BUSY);
     }
 }
 

--- a/src/drivers/si4063/si4063.c
+++ b/src/drivers/si4063/si4063.c
@@ -110,6 +110,7 @@ static int si4063_wait_for_cts()
 
     if (timeout == 0) {
         log_error("ERROR: Si4063 timeout\n");
+        set_error_code(ERROR_SI4063_TIMEOUT);
     }
 
     return timeout > 0 ? HAL_OK : HAL_ERROR;
@@ -135,6 +136,7 @@ static int si4063_read_response(uint8_t length, uint8_t *data)
 
     if (timeout == 0) {
         log_error("ERROR: Si4063 timeout\n");
+        set_error_code(ERROR_SI4063_TIMEOUT);
         si4063_set_chip_select(false);
         return HAL_ERROR;
     }
@@ -814,6 +816,7 @@ int si4063_init()
 
     if (si4063_power_up() != HAL_OK) {
         log_error("ERROR: Error powering up Si4063\n");
+        set_error_code(ERROR_SI4063_POWERUP);
         return HAL_ERROR;
     }
 
@@ -821,6 +824,7 @@ int si4063_init()
     uint16_t part = si4063_read_part_info();
     if (part != 0x4063) {
         log_error("ERROR: Unknown or missing Si4063 part number: 0x%04x\n", part);
+        set_error_code(ERROR_SI4063_PART_NUMBER);
         return HAL_ERROR;
     }
 

--- a/src/errors.c
+++ b/src/errors.c
@@ -1,0 +1,15 @@
+#include "errors.h"
+
+volatile uint8_t system_error_code = ERROR_NONE;
+
+void set_error_code(uint8_t code)
+{
+    system_error_code = code;
+}
+
+void clear_error_code(uint8_t code)
+{
+    if (system_error_code == code) {
+        system_error_code = ERROR_NONE;
+    }
+}

--- a/src/errors.h
+++ b/src/errors.h
@@ -1,0 +1,74 @@
+#ifndef __ERRORS_H
+#define __ERRORS_H
+
+#include <stdint.h>
+
+/*
+ * System error codes for diagnostics.
+ *
+ * A single global error code (system_error_code) records the most recent error
+ * encountered anywhere in the firmware. It is mirrored into telemetry_data by
+ * telemetry_collect() and can be transmitted:
+ *   - in text messages (APRS / CW / ...) via the $err template variable
+ *     (rendered as a zero-padded decimal, e.g. "00", "23")
+ *   - in Horus Binary v3 as an "err" extra sensor field when
+ *     HORUS_V3_TX_ERROR_CODE is enabled
+ *
+ * Semantics: latest error wins (set_error_code overwrites). Recoverable
+ * subsystems clear their own code on recovery via clear_error_code(), which
+ * only resets to ERROR_NONE if the current code still belongs to that subsystem
+ * (so it does not wipe a more recent error from another subsystem).
+ *
+ * Codes are grouped in blocks of 20 to leave room to expand each category.
+ */
+
+#define ERROR_NONE                  0
+
+// 1-19: startup / initialization failures
+#define ERROR_GPS_INIT              1
+#define ERROR_BMP280_INIT           2
+#define ERROR_BME68X_INIT           3
+#define ERROR_BME690_INIT           4
+#define ERROR_RADSENS_INIT          5
+#define ERROR_SI5351_INIT           6
+
+// 20-39: runtime sensor read failures (recoverable in flight)
+#define ERROR_BMP280_READ           20
+#define ERROR_BME68X_READ           21
+#define ERROR_BME690_READ           22
+#define ERROR_RADSENS_READ          23
+
+// 40-59: telemetry encoding failures
+#define ERROR_HORUS_V3_ENCODE       40
+#define ERROR_HORUS_V3_EXT_ENCODE   41
+
+// 60-79: radio / I2C low-level failures
+#define ERROR_I2C_BUS_BUSY          60
+#define ERROR_SI4063_TIMEOUT        61
+#define ERROR_SI4063_POWERUP        62
+#define ERROR_SI4063_PART_NUMBER    63
+#define ERROR_RADIO_TX_TIMEOUT      64
+
+// 80-99: GPS runtime failures
+#define ERROR_GPS_CONFIG            80
+#define ERROR_GPS_POWER_SAVE        81
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Most recent error code seen anywhere in the firmware. ERROR_NONE when healthy.
+extern volatile uint8_t system_error_code;
+
+// Record an error (latest wins).
+void set_error_code(uint8_t code);
+
+// Clear an error on recovery: resets to ERROR_NONE only if the current code is
+// still `code`, so a newer error from another subsystem is preserved.
+void clear_error_code(uint8_t code);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -204,12 +204,14 @@ int main(void)
             set_green_led(false);
             if (++gps_init_attempts >= GPS_INIT_RED_LED_RETRY_THRESHOLD) {
                 set_red_led(true);
+                set_error_code(ERROR_GPS_INIT);
             }
             log_error("GPS initialization failed, retrying...\n");
             delay_ms(1000);
             goto gps_init;
         }
         set_red_led(false);
+        clear_error_code(ERROR_GPS_INIT);
 
     #ifdef DFM17
         log_info("Timepulse init\n");
@@ -232,6 +234,7 @@ int main(void)
     }
     if (!success) {
         set_red_led(true);
+        set_error_code(ERROR_BMP280_INIT);
     }
 #endif
 
@@ -246,6 +249,7 @@ int main(void)
     }
     if (!success) {
         set_red_led(true);
+        set_error_code(ERROR_BME68X_INIT);
     }
 #endif
 
@@ -260,6 +264,7 @@ int main(void)
     }
     if (!success) {
         set_red_led(true);
+        set_error_code(ERROR_BME690_INIT);
     }
 #endif
 
@@ -274,6 +279,7 @@ int main(void)
     }
     if (!success) {
         set_red_led(true);
+        set_error_code(ERROR_RADSENS_INIT);
     }
 #endif
 
@@ -288,6 +294,7 @@ int main(void)
     }
     if (!success) {
         set_red_led(true);
+        set_error_code(ERROR_SI5351_INIT);
     }
 #endif
 

--- a/src/radio_si4032.c
+++ b/src/radio_si4032.c
@@ -346,6 +346,7 @@ void radio_handle_fifo_si4032(radio_transmit_entry *entry, radio_module_state *s
     int err = si4032_wait_for_tx_complete(500);
     if (err != HAL_OK) {
         log_error("Error waiting for tx complete: %d\n", err);
+        set_error_code(ERROR_RADIO_TX_TIMEOUT);
     }
 
 #ifdef RADIO_LOGGING_ENABLE

--- a/src/radio_si4063.c
+++ b/src/radio_si4063.c
@@ -329,6 +329,7 @@ void radio_handle_fifo_si4063(radio_transmit_entry *entry, radio_module_state *s
     int err = si4063_wait_for_tx_complete(1000);
     if(err != HAL_OK) {
         log_error("Error waiting for tx complete: %d\n", err);
+        set_error_code(ERROR_RADIO_TX_TIMEOUT);
     }
 
 #ifdef RADIO_LOGGING_ENABLE

--- a/src/radsens_handler.cpp
+++ b/src/radsens_handler.cpp
@@ -150,6 +150,7 @@ bool radsens_read_telemetry(telemetry_data *data)
         if (!success) {
             // Pulse counter does not need to be zeroed
             data->radiation_intensity_uR_h = 0;
+            set_error_code(ERROR_RADSENS_READ);
             return false;
         }
     }
@@ -157,8 +158,9 @@ bool radsens_read_telemetry(telemetry_data *data)
     success = radsens_read(&data->pulse_count, &data->radiation_intensity_uR_h, NULL);
 
     if (!success) {
-        if(LEDS_ENABLE)
+        if (LEDS_ENABLE) {
             set_red_led(true);
+        }
 
         log_info("RadSens re-init\n");
         success = radsens_handler_init_sensor();
@@ -171,8 +173,15 @@ bool radsens_read_telemetry(telemetry_data *data)
             data->radiation_intensity_uR_h = 0;
         }
 
-        if(LEDS_ENABLE)
+        if (LEDS_ENABLE) {
             set_red_led(false);
+        }
+    }
+
+    if (success) {
+        clear_error_code(ERROR_RADSENS_READ);
+    } else {
+        set_error_code(ERROR_RADSENS_READ);
     }
 
     radsens_initialization_required = !success;

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -33,6 +33,9 @@ void telemetry_collect(telemetry_data *data)
 {
     log_info("Collecting telemetry...\n");
 
+    // Snapshot the latest system error code for $err and Horus v3 telemetry
+    data->error_code = system_error_code;
+
     data->button_adc_value = system_get_button_adc_value();
     data->battery_voltage_millivolts = system_get_battery_voltage_millivolts();
     log_info("Battery voltage: %u mV\n", data->battery_voltage_millivolts);

--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -32,6 +32,9 @@ typedef struct _telemetry_data {
     int cap_trim_offset;
     int32_t timepulse_error_us;
     uint8_t po_state;
+
+    // Most recent system error code (see errors.h)
+    uint8_t error_code;
 } telemetry_data;
 
 void telemetry_collect(telemetry_data *data);

--- a/src/template.c
+++ b/src/template.c
@@ -119,6 +119,11 @@ size_t template_replace(char *dest, size_t dest_len, char *src, telemetry_data *
     strlcpy(temp, dest, dest_len);
     str_replace(dest, dest_len, temp, "$gu", replacement);
 
+    // System error code (see errors.h), zero-padded decimal
+    snprintf(replacement, sizeof(replacement), "%02d", (int) data->error_code);
+    strlcpy(temp, dest, dest_len);
+    str_replace(dest, dest_len, temp, "$err", replacement);
+
     // $apc pre-increments the shared APRS packet counter on each substitution
     snprintf(replacement, sizeof(replacement), "%u", (unsigned int) aprs_packet_counter);
     strlcpy(temp, dest, dest_len);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,54 +1,83 @@
 #include "utils.h"
 
+// Replaces every occurrence of "rep" in "orig" with "with", writing the result
+// into "dest" (a buffer of dest_len bytes, including the terminating NUL).
+//
+// The output is always NUL-terminated and never exceeds dest_len. If the fully
+// expanded result would not fit, it is truncated to fill the buffer rather than
+// dropped: replacements are still performed up to the point the buffer fills,
+// so the destination never contains unexpanded "rep" tokens that could have
+// been replaced within the available space. This matters for templated radio
+// payloads (e.g. APRS comments), where a buffer-sized message must contain the
+// substituted values, not the literal template variables.
+//
+// Returns the length (excluding NUL) of the string written to dest.
 size_t str_replace(char *dest, size_t dest_len, char *orig, char *rep, char *with)
 {
-    char *ins;    // the next insert point
-    char *tmp;    // varies
-    size_t len_rep;  // length of rep (the string to remove)
-    size_t len_with; // length of with (the string to replace rep with)
-    size_t len_front; // distance between rep and end of last rep
-    size_t count;    // number of replacements
-
-    // sanity checks and initialization
-    if (!orig || !rep) {
+    if (!dest || dest_len == 0) {
         return 0;
     }
-    len_rep = strlen(rep);
-    if (len_rep == 0) {
-        return 0; // empty rep causes infinite loop during count
+
+    if (!orig || !rep) {
+        dest[0] = '\0';
+        return 0;
     }
+
+    size_t len_rep = strlen(rep);
+    char *out = dest;
+    size_t remaining = dest_len - 1; // reserve space for the terminating NUL
+
+    // An empty "rep" would match endlessly; just copy orig verbatim (truncated).
+    if (len_rep == 0) {
+        size_t n = strlen(orig);
+        if (n > remaining) {
+            n = remaining;
+        }
+        memcpy(out, orig, n);
+        out += n;
+        *out = '\0';
+        return (size_t) (out - dest);
+    }
+
     if (!with) {
         with = "";
     }
-    len_with = strlen(with);
+    size_t len_with = strlen(with);
 
-    // count the number of replacements needed
-    ins = orig;
-    for (count = 0; (tmp = strstr(ins, rep)); ++count) {
-        ins = tmp + len_rep;
+    char *cursor = orig;
+    char *match;
+    while (remaining > 0 && (match = strstr(cursor, rep)) != NULL) {
+        // Copy the literal segment preceding the match.
+        size_t front = (size_t) (match - cursor);
+        if (front > remaining) {
+            front = remaining;
+        }
+        memcpy(out, cursor, front);
+        out += front;
+        remaining -= front;
+        if (remaining == 0) {
+            break;
+        }
+
+        // Copy the replacement, truncating it if the buffer is nearly full.
+        size_t with_copy = len_with > remaining ? remaining : len_with;
+        memcpy(out, with, with_copy);
+        out += with_copy;
+        remaining -= with_copy;
+
+        cursor = match + len_rep;
     }
 
-    size_t required_len = strlen(orig) + (len_with - len_rep) * count + 1;
-    if (dest_len < required_len) {
-        return 0;
+    // Copy whatever remains after the last match (or all of orig if no match).
+    if (remaining > 0) {
+        size_t tail = strlen(cursor);
+        if (tail > remaining) {
+            tail = remaining;
+        }
+        memcpy(out, cursor, tail);
+        out += tail;
     }
 
-    tmp = dest;
-
-    // first time through the loop, all the variable are set correctly
-    // from here on,
-    //    tmp points to the end of the result string
-    //    ins points to the next occurrence of rep in orig
-    //    orig points to the remainder of orig after "end of rep"
-    while (count--) {
-        ins = strstr(orig, rep);
-        len_front = ins - orig;
-        tmp = strncpy(tmp, orig, len_front) + len_front;
-        tmp = strcpy(tmp, with) + len_with;
-        orig += len_front + len_rep; // move to next "end of rep"
-    }
-
-    strcpy(tmp, orig);
-
-    return required_len - 1;
+    *out = '\0';
+    return (size_t) (out - dest);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,24 +1,69 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.13)
 
-#SET(CMAKE_SYSTEM_NAME Linux)
-#SET(CMAKE_SYSTEM_VERSION 1)
+# Standalone NATIVE test project. Do not configure this via the firmware's ARM
+# toolchain - the tests are meant to be compiled and run on the host machine:
+#
+#   cmake -S tests -B build-tests
+#   cmake --build build-tests
+#   ctest --test-dir build-tests --output-on-failure
+#
+# Build/run a single test:
+#   cmake --build build-tests --target template_test
+#   ./build-tests/template_test
+project(RS41ng_tests C CXX)
 
-project(RS41ng_test C CXX)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
-set(BINARY ${CMAKE_PROJECT_NAME})
+set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
-SET(CMAKE_C_FLAGS "${COMMON_FLAGS} -std=gnu99")
+# The firmware requires a hardware type to be defined. Default to RS41 for the
+# host tests; override with -DDFM17=1 or -DRS41_RSM4X4=1 when configuring.
+if(NOT DEFINED RS41 AND NOT DEFINED DFM17 AND NOT DEFINED RS41_RSM4X4)
+    set(RS41 1)
+endif()
+foreach(hw RS41 RS41_RSM4X4 DFM17)
+    if(DEFINED ${hw} AND ${hw})
+        add_compile_definitions(${hw}=1)
+    endif()
+endforeach()
 
-file(GLOB_RECURSE USER_SOURCES "../src/config.c" "../src/codecs/*.c" "../src/template.c" "../src/utils.c" "../src/strlcpy.c")
-file(GLOB_RECURSE USER_SOURCES_CXX "../src/codecs/*.cpp")
-file(GLOB_RECURSE USER_HEADERS "../src/codecs/*.h" "../src/template.h" "../src/utils.h" "../src/config.h" "../src/strlcpy.h")
+# On macOS the libc <string.h> defines a fortifying strlcpy(...) macro that
+# clashes with the project's own strlcpy declaration. Disable fortification so
+# the host build matches the firmware's plain libc behaviour.
+if(APPLE)
+    add_compile_definitions(_FORTIFY_SOURCE=0)
+endif()
 
-file(GLOB_RECURSE TEST_SOURCES "*.c")
-file(GLOB_RECURSE TEST_SOURCES_CXX "*.cpp")
-file(GLOB_RECURSE TEST_HEADERS "*.h")
+include_directories(${SRC_DIR})
 
-set(SOURCES ${TEST_SOURCES})
+# Host-compilable firmware sources shared by the tests (no HAL / hardware deps).
+set(COMMON_SOURCES
+        ${SRC_DIR}/config.c
+        ${SRC_DIR}/template.c
+        ${SRC_DIR}/utils.c
+        ${SRC_DIR}/strlcpy.c
+        ${SRC_DIR}/codecs/aprs/aprs.c
+        ${SRC_DIR}/codecs/aprs/aprs_position.c
+        ${SRC_DIR}/codecs/ax25/ax25.c
+        ${SRC_DIR}/codecs/bell/bell.c
+        ${SRC_DIR}/codecs/morse/morse.c
+)
 
-add_executable(${BINARY} ${TEST_SOURCES} ${USER_SOURCES})
+enable_testing()
 
-add_test(NAME ${BINARY} COMMAND ${BINARY})
+# One executable + one ctest per *_test.c file that defines a real entry point.
+# Tests can be parked by renaming main() (e.g. bell_test.c uses main2()); those
+# are skipped automatically.
+file(GLOB TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*_test.c)
+foreach(test_src ${TEST_SOURCES})
+    file(READ ${test_src} test_contents)
+    if(test_contents MATCHES "int[ \t\r\n]+main[ \t]*\\(")
+        get_filename_component(test_name ${test_src} NAME_WE)
+        add_executable(${test_name} ${test_src} ${COMMON_SOURCES})
+        add_test(NAME ${test_name} COMMAND ${test_name})
+    else()
+        get_filename_component(test_name ${test_src} NAME_WE)
+        message(STATUS "Skipping ${test_name}: no main() entry point")
+    endif()
+endforeach()

--- a/tests/bell_test.c
+++ b/tests/bell_test.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
+#include <assert.h>
 
 #include "codecs/bell/bell.h"
 #include "codecs/aprs/aprs_position.h"
@@ -7,68 +9,48 @@
 #include "telemetry.h"
 #include "config.h"
 
-int main2(void)
+int main(void)
 {
     fsk_encoder fsk_encoder;
-
-    char *gg = "gasfa";
-    char test[100];
-    snprintf(test, sizeof(test), "%3$s %4$s %2$s\n", "1fd", gg, "3aa", "4ab");
-    printf("%s\n", test);
 
     bell_encoder_new(&fsk_encoder, 1200, 0, bell202_tones);
 
     telemetry_data telemetry;
     memset(&telemetry, 0, sizeof(telemetry_data));
 
-    char aprs_comment[256];
-    snprintf(aprs_comment, sizeof(aprs_comment),
-            APRS_COMMENT,
-            telemetry.locator,
-            telemetry.temperature_celsius_100 / 100,
-            telemetry.humidity_percentage_100 / 100,
-            telemetry.pressure_mbar_100 / 100,
-            telemetry.gps.time_of_week_millis,
-            telemetry.gps.hours, telemetry.gps.minutes, telemetry.gps.seconds);
-
     uint8_t aprs_packet[256];
     size_t aprs_length = aprs_generate_position(
-                aprs_packet, sizeof(aprs_packet), &telemetry, APRS_SYMBOL_TABLE, APRS_SYMBOL, false, aprs_comment);
+            aprs_packet, sizeof(aprs_packet), &telemetry, APRS_SYMBOL_TABLE, APRS_SYMBOL, false, APRS_COMMENT);
+
+    // Zeroed telemetry + built-in config produce a deterministic APRS position report.
+    assert(aprs_length == 73);
+    aprs_packet[aprs_length] = '\0';
+    assert(strstr((char *) aprs_packet, "!0000.00S/00000.00WO000/000/A=000000") != NULL);
+    assert(strstr((char *) aprs_packet, "https://amateur.sondehub.org/4FSKTEST") != NULL);
 
     uint8_t payload[256];
+    memset(payload, 0, sizeof(payload));
     size_t payload_length = ax25_encode_packet_aprs(APRS_CALLSIGN, APRS_SSID, APRS_DESTINATION, APRS_DESTINATION_SSID, APRS_RELAYS,
-               (char *) aprs_packet, aprs_length, payload);
+            (char *) aprs_packet, aprs_length, payload);
 
-    printf("Full payload length: %ld\n", payload_length);
+    printf("Full payload length: %zu\n", payload_length);
+    assert(payload_length == 93);
 
-    for (int i = 0; i < payload_length; i++) {
-        uint8_t c = payload[i];
-        if (c >= 0x20 && c <= 0x7e) {
-            printf("%c", c);
-        } else {
-            printf(" [%02X] ", c);
-        }
+    // Encode the actual packet (payload_length), not the whole buffer.
+    bell_encoder_set_data(&fsk_encoder, payload_length, payload);
+
+    size_t tone_count = 0;
+    int8_t tone;
+    while ((tone = bell_encoder_next_tone(&fsk_encoder)) >= 0) {
+        assert(tone == 0 || tone == 1);
+        tone_count++;
     }
-
-    printf("\n");
-
-    bell_encoder_set_data(&fsk_encoder, sizeof(payload), payload);
-
-    size_t index = 0;
-    while (true) {
-        int8_t tone = bell_encoder_next_tone(&fsk_encoder);
-        if (tone < 0) {
-            break;
-        }
-
-        printf("%d ", tone);
-
-        index++;
-
-        if (index % 8 == 0) {
-            printf("\n");
-        }
-    };
+    printf("Bell202 tone count: %zu\n", tone_count);
+    assert(tone_count == 745);
 
     bell_encoder_destroy(&fsk_encoder);
+
+    printf("All bell_test assertions passed\n");
+
+    return 0;
 }

--- a/tests/morse_test.c
+++ b/tests/morse_test.c
@@ -1,28 +1,55 @@
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 
 #include "codecs/morse/morse.h"
 #include "config.h"
 
-int main4(void)
+int main(void)
 {
     fsk_encoder morse;
 
-    printf("%d\n", MORSE_WPM_TO_SYMBOL_RATE(20));
-    printf("%d\n", MORSE_WPM_TO_SYMBOL_RATE(15));
-    printf("%d\n", MORSE_WPM_TO_SYMBOL_RATE(10));
+    // PARIS timing: symbol rate (ms per unit) derived from words-per-minute.
+    printf("WPM rates: %d %d %d\n",
+            MORSE_WPM_TO_SYMBOL_RATE(20), MORSE_WPM_TO_SYMBOL_RATE(15), MORSE_WPM_TO_SYMBOL_RATE(10));
+    assert(MORSE_WPM_TO_SYMBOL_RATE(20) == 16);
+    assert(MORSE_WPM_TO_SYMBOL_RATE(15) == 12);
+    assert(MORSE_WPM_TO_SYMBOL_RATE(10) == 8);
 
     char *input = "TEST T";
 
-    morse_encoder_new(&morse, 25);
+    // Expected on/off keying for "TEST T":
+    //   T = dah (111), E = dit (1), S = dit dit dit (10101), T = dah (111)
+    //   inter-letter gap = 000, word gap = 0000000
+    int8_t expected[] = {
+            1, 1, 1,                // T
+            0, 0, 0,                // letter gap
+            1,                      // E
+            0, 0, 0,                // letter gap
+            1, 0, 1, 0, 1,          // S
+            0, 0, 0,                // letter gap
+            1, 1, 1,                // T
+            0, 0, 0, 0, 0, 0, 0,    // word gap
+            1, 1, 1,                // T
+    };
+    size_t expected_count = sizeof(expected) / sizeof(expected[0]);
 
+    morse_encoder_new(&morse, 25);
     morse_encoder_set_data(&morse, strlen(input), (uint8_t *) input);
 
     int8_t tone_index;
-
+    size_t i = 0;
     while ((tone_index = morse_encoder_next_tone(&morse)) >= 0) {
         printf("CW: %d\n", tone_index);
+        assert(i < expected_count);
+        assert(tone_index == expected[i]);
+        i++;
     }
+    assert(i == expected_count);
 
     morse_encoder_destroy(&morse);
+
+    printf("All morse_test assertions passed\n");
+
+    return 0;
 }

--- a/tests/template_test.c
+++ b/tests/template_test.c
@@ -1,7 +1,9 @@
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include "strlcpy.h"
 #include "template.h"
+#include "codecs/aprs/aprs.h"
 
 int main(void)
 {
@@ -25,5 +27,48 @@ int main(void)
 
     printf("%s\n", dest);
 
-    printf("%03d\n", data.internal_temperature_celsius_100 / 100);
+    assert(strcmp(dest, "DE 4FSKTEST: 3247 KP21FA, 18:33:51, 110022330, Ti-7 Te24 68 1023") == 0);
+
+    // $apc reads the shared global APRS packet counter
+    aprs_packet_counter = 1234;
+    data.gps.satellites_visible = 10;
+    data.gps.climb_cm_per_second = 100;
+    data.button_adc_value = 456;
+    data.radiation_intensity_uR_h = 1231;
+    data.data_counter = 1235;
+    data.gps.updated = 1;
+    data.gps.latitude_degrees_10000000 = 1234567890;
+    data.gps.longitude_degrees_10000000 = 1324567890;
+    data.gps.altitude_mm = 12345;
+    data.error_code = 23;
+
+    source = "/P$apcS$svT$tiV$bvC$clA$bu $ri $dc $gu $lat $lon $alt E$err";
+    template_replace(dest, sizeof(dest), source, &data);
+
+    printf("%s\n", dest);
+
+    // $err renders as a zero-padded 2-digit decimal
+    assert(strcmp(dest, "/P1234S10T-7V3247C1A456 1231 1235 1 123456 132456 12 E23") == 0);
+
+    // Regression: a template longer than the destination buffer (as happens with
+    // a 64-byte message buffer and a long comment, for example) must still expand the
+    // template variables and truncate the tail - never transmit literal $vars.
+    char small[64];
+    source = "/P$apcS$svT$tiV$bvC$clA$bu high-altitude balloon APRS 432.500, Horus 432.300, Wenet 436.750";
+    template_replace(small, sizeof(small), source, &data);
+
+    printf("%s\n", small);
+
+    assert(strlen(small) < sizeof(small));
+    // Variables are expanded, not left as literal tokens...
+    assert(strstr(small, "$bv") == NULL);
+    assert(strstr(small, "$bu") == NULL);
+    assert(strstr(small, "$apc") == NULL);
+    assert(strstr(small, "$ti") == NULL);
+    // ...and their substituted values are present.
+    assert(strncmp(small, "/P1234S10T-7V3247C1A456 ", 23) == 0);
+
+    printf("All template_test assertions passed\n");
+
+    return 0;
 }

--- a/web/config-schema.yaml
+++ b/web/config-schema.yaml
@@ -1287,6 +1287,14 @@ horus_v3:
     default: false
     tier: intermediate
 
+  error_code:
+    define: HORUS_V3_TX_ERROR_CODE
+    label: "Transmit Error Code"
+    description: "Transmit the system error code (see errors.h, also available as $err) as an \"err\" extra sensor field"
+    type: bool
+    default: false
+    tier: intermediate
+
   time_sync_seconds:
     define: HORUS_V3_TIME_SYNC_SECONDS
     label: "Time Sync Interval (s)"
@@ -2146,6 +2154,149 @@ jt65:
       min: 0
       max: 3600
 
+# ------------------------------------------------------------------------------
+# Landed Mode Settings
+# ------------------------------------------------------------------------------
+landed:
+  _section: "Landed Mode"
+  _description: "Battery conservation after landing. When enabled, landed mode is armed once altitude exceeds the arm threshold during ascent, then requires altitude to drop back below it before landing detection begins. After landing (velocity near zero for the stationary period), GPS and radio sleep; the system periodically wakes, acquires a fix, transmits all enabled modes once, then sleeps again. An auto-detected geofence around the landing site disables landed mode if the unit moves."
+  _tier: intermediate
+  _order: 22
+
+  enable:
+    define: LANDED_MODE_ENABLE
+    label: "Enable Landed Mode"
+    description: "Enable battery conservation after the balloon has landed."
+    type: bool
+    default: false
+    tier: intermediate
+
+  arm_altitude_meters:
+    define: LANDED_MODE_ARM_ALTITUDE_METERS
+    label: "Arm Altitude (m)"
+    description: "Altitude in meters that must be exceeded during ascent to arm landed mode."
+    type: integer
+    default: 5000
+    tier: advanced
+    visible_when: "landed.enable"
+    validation:
+      min: 0
+      max: 50000
+
+  climb_threshold_cm_s:
+    define: LANDED_MODE_CLIMB_THRESHOLD_CM_S
+    label: "Climb Threshold (cm/s)"
+    description: "Maximum absolute vertical speed in cm/s to consider \"stationary\" (50 = 0.5 m/s)."
+    type: integer
+    default: 50
+    tier: advanced
+    visible_when: "landed.enable"
+    validation:
+      min: 0
+      max: 10000
+
+  speed_threshold_cm_s:
+    define: LANDED_MODE_SPEED_THRESHOLD_CM_S
+    label: "Speed Threshold (cm/s)"
+    description: "Maximum ground speed in cm/s to consider \"stationary\" (50 = 0.5 m/s)."
+    type: integer
+    default: 50
+    tier: advanced
+    visible_when: "landed.enable"
+    validation:
+      min: 0
+      max: 10000
+
+  stationary_seconds:
+    define: LANDED_MODE_STATIONARY_SECONDS
+    label: "Stationary Time (s)"
+    description: "Number of consecutive seconds the unit must be stationary before entering landed mode."
+    type: integer
+    default: 600
+    tier: advanced
+    visible_when: "landed.enable"
+    validation:
+      min: 0
+      max: 86400
+
+  sleep_seconds:
+    define: LANDED_MODE_SLEEP_SECONDS
+    label: "Sleep Duration (s)"
+    description: "Sleep duration in seconds between wake-transmit cycles while in landed mode."
+    type: integer
+    default: 300
+    tier: advanced
+    visible_when: "landed.enable"
+    validation:
+      min: 0
+      max: 86400
+
+  gps_fix_timeout_seconds:
+    define: LANDED_MODE_GPS_FIX_TIMEOUT_SECONDS
+    label: "GPS Fix Timeout (s)"
+    description: "Maximum time in seconds to wait for GPS fix after waking before transmitting anyway."
+    type: integer
+    default: 120
+    tier: advanced
+    visible_when: "landed.enable"
+    validation:
+      min: 0
+      max: 3600
+
+  transmit_seconds:
+    define: LANDED_MODE_TRANSMIT_SECONDS
+    label: "Transmit Cycle Timeout (s)"
+    description: "Safety maximum time in seconds for the transmit cycle (normally the cycle completes on its own)."
+    type: integer
+    default: 30
+    tier: advanced
+    visible_when: "landed.enable"
+    validation:
+      min: 0
+      max: 3600
+
+  geofence_radius_meters:
+    define: LANDED_MODE_GEOFENCE_RADIUS_METERS
+    label: "Geofence Radius (m)"
+    description: "Geofence radius in meters from the landing point. If the unit moves beyond this radius, landed mode is disabled (returns to armed). Set to 0 to disable the geofence."
+    type: integer
+    default: 100
+    tier: advanced
+    visible_when: "landed.enable"
+    validation:
+      min: 0
+      max: 100000
+
+  pip_enable:
+    define: LANDED_MODE_PIP_ENABLE
+    label: "Enable Pip While Sleeping"
+    description: "Emit a PIP at the configured interval while sleeping, without waking the GPS. Uses the existing PIP radio infrastructure (morse 'E' character)."
+    type: bool
+    default: true
+    tier: advanced
+    visible_when: "landed.enable"
+
+  pip_interval_seconds:
+    define: LANDED_MODE_PIP_INTERVAL_SECONDS
+    label: "Pip Interval (s)"
+    description: "Interval in seconds between pips while sleeping in landed mode."
+    type: integer
+    default: 10
+    tier: advanced
+    visible_when: "landed.enable && landed.pip_enable"
+    validation:
+      min: 1
+      max: 3600
+
+  leds_transmit_only:
+    define: LANDED_MODE_LEDS_TRANSMIT_ONLY
+    label: "LEDs Only During Transmit"
+    description: "When true, LEDs are forced off during landed sleep/acquire states and only enabled during TRANSMITTING or PIPPING to conserve power."
+    type: bool
+    default: true
+    tier: advanced
+    visible_when: "landed.enable"
+
 # ==============================================================================
 # Template variables reference (for UI help text)
 # ==============================================================================
@@ -2156,6 +2307,7 @@ _template_variables:
   - { var: "$loc8", description: "Locator (8 chars)" }
   - { var: "$loc12", description: "Locator (12 chars)" }
   - { var: "$bv", description: "Battery voltage in mV (up to 4 chars)" }
+  - { var: "$bu", description: "Button ADC value (raw reading, up to 4 chars)" }
   - { var: "$te", description: "External temperature in C (up to 3 chars)" }
   - { var: "$ti", description: "Internal temperature in C (up to 3 chars)" }
   - { var: "$hu", description: "Humidity % (up to 3 chars)" }
@@ -2174,6 +2326,8 @@ _template_variables:
   - { var: "$pc", description: "Pulse counter value (wraps to zero at 65535, 16-bit unsigned)" }
   - { var: "$ri", description: "Radiation intensity in uR/h (up to 5 chars)" }
   - { var: "$dc", description: "Data counter value (wraps to zero at 65535, 16-bit unsigned)" }
+  - { var: "$apc", description: "APRS packet counter value (16-bit unsigned)" }
   - { var: "$gu", description: "GPS data update indicator (1 if updated, 0 otherwise)" }
+  - { var: "$err", description: "System error code, zero-padded to 2 digits (see errors.h; 0 = no error)" }
   - { var: "$ct", description: "Clock calibration trim value (0-31, DFM-17 only)" }
   - { var: "$cc", description: "Clock calibration change count (DFM-17 only)" }

--- a/web/src/test/config/landed-and-error-code.test.ts
+++ b/web/src/test/config/landed-and-error-code.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { load as yamlLoad } from "js-yaml";
+import type { Schema } from "@/types/schema";
+import type { ConfigState } from "@/types/config";
+import { buildDefaults } from "@/config/defaults";
+import { generateConfigH } from "@/config/generate-header";
+import { getField, getSectionFieldKeys } from "@/config/schema-registry";
+
+/**
+ * Verifies that the HORUS_V3_TX_ERROR_CODE toggle and the full LANDED_MODE_*
+ * parameter set exist in the schema with defines/defaults that mirror config.h
+ * exactly, and that the header generator emits them.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const schema = yamlLoad(
+  readFileSync(resolve(here, "../../../config-schema.yaml"), "utf8")
+) as Schema;
+
+// (sectionKey, fieldKey) -> [#define name, default value], mirrored from src/config.h
+const LANDED_FIELDS: Array<[string, string, string | number | boolean]> = [
+  ["enable", "LANDED_MODE_ENABLE", false],
+  ["arm_altitude_meters", "LANDED_MODE_ARM_ALTITUDE_METERS", 5000],
+  ["climb_threshold_cm_s", "LANDED_MODE_CLIMB_THRESHOLD_CM_S", 50],
+  ["speed_threshold_cm_s", "LANDED_MODE_SPEED_THRESHOLD_CM_S", 50],
+  ["stationary_seconds", "LANDED_MODE_STATIONARY_SECONDS", 600],
+  ["sleep_seconds", "LANDED_MODE_SLEEP_SECONDS", 300],
+  ["gps_fix_timeout_seconds", "LANDED_MODE_GPS_FIX_TIMEOUT_SECONDS", 120],
+  ["transmit_seconds", "LANDED_MODE_TRANSMIT_SECONDS", 30],
+  ["geofence_radius_meters", "LANDED_MODE_GEOFENCE_RADIUS_METERS", 100],
+  ["pip_enable", "LANDED_MODE_PIP_ENABLE", true],
+  ["pip_interval_seconds", "LANDED_MODE_PIP_INTERVAL_SECONDS", 10],
+  ["leds_transmit_only", "LANDED_MODE_LEDS_TRANSMIT_ONLY", true],
+];
+
+describe("HORUS_V3_TX_ERROR_CODE schema field", () => {
+  it("exists in horus_v3 with the right define, type and default", () => {
+    const field = getField(schema, "horus_v3", "error_code");
+    expect(field).not.toBeNull();
+    expect(field?.define).toBe("HORUS_V3_TX_ERROR_CODE");
+    expect(field?.type).toBe("bool");
+    expect(field?.default).toBe(false);
+    expect(field?.description).toBeTruthy();
+  });
+});
+
+describe("Landed Mode schema section", () => {
+  it("is a section with all parameters mirroring config.h", () => {
+    expect((schema.landed as { _section?: string })?._section).toBe("Landed Mode");
+
+    const fieldKeys = getSectionFieldKeys(schema, "landed");
+    expect(fieldKeys).toEqual(LANDED_FIELDS.map(([key]) => key));
+
+    for (const [fieldKey, define, def] of LANDED_FIELDS) {
+      const field = getField(schema, "landed", fieldKey);
+      expect(field, fieldKey).not.toBeNull();
+      expect(field?.define, fieldKey).toBe(define);
+      expect(field?.default, fieldKey).toBe(def);
+      expect(field?.description, fieldKey).toBeTruthy();
+    }
+  });
+});
+
+describe("header generation for the new fields", () => {
+  it("emits the defines at default values", () => {
+    const config: ConfigState = buildDefaults(schema);
+    const header = generateConfigH(schema, config);
+
+    expect(header).toContain("#define HORUS_V3_TX_ERROR_CODE false");
+    for (const [, define, def] of LANDED_FIELDS) {
+      const formatted = typeof def === "boolean" ? String(def) : String(def);
+      expect(header).toContain(`#define ${define} ${formatted}`);
+    }
+  });
+
+  it("reflects overridden values (landed enabled, error code on)", () => {
+    const config: ConfigState = buildDefaults(schema);
+    config.landed = { ...config.landed, enable: true, sleep_seconds: 120 };
+    config.horus_v3 = { ...config.horus_v3, error_code: true };
+
+    const header = generateConfigH(schema, config);
+
+    expect(header).toContain("#define LANDED_MODE_ENABLE true");
+    expect(header).toContain("#define LANDED_MODE_SLEEP_SECONDS 120");
+    expect(header).toContain("#define HORUS_V3_TX_ERROR_CODE true");
+  });
+});


### PR DESCRIPTION
Add support for error codes that can be transmitted over messages or Horus V3 for exposing issues in firmware. Add support for landed mode in web firmware configurator.

Changed the string (template) replacement implementation so that it always replaces all variables and truncates the output if it doesn't fit the destination. Previously it would leave variables unexpanded, which was confusing.