### PR TITLE
Fix RADIO_TX_WAIT_FOR_GPS_LOCK never gating TX

### DIFF
--- a/src/radio.c
+++ b/src/radio.c
@@ -1146,10 +1146,20 @@ static radio_transmit_entry *radio_find_ready_entry()
         return radio_current_transmit_entry;
     }
 
-    // Tier 2: scan time-synced entries for matching window
     gps_data gps;
     gps_driver_get_current_gps_data(&gps);
 
+#if RADIO_TX_WAIT_FOR_GPS_LOCK
+    if (GPS_HAS_FIX(gps)) {
+        gps_fix_ever_acquired = true;
+    }
+
+    if (!gps_fix_ever_acquired) {
+        return NULL;
+    }
+#endif
+
+    // Tier 2: scan time-synced entries for matching window
     if (gps.updated) {
         uint32_t time_millis = gps.time_of_week_millis - (gps_time_leap_seconds * 1000);
 


### PR DESCRIPTION
## Summary
- `RADIO_TX_WAIT_FOR_GPS_LOCK` declared `gps_fix_ever_acquired` in `radio.c` but never read or wrote it, so `radio_find_ready_entry()` never checked GPS fix status before scheduling a transmission — the first transmission after boot fired immediately regardless of the setting.
- Wires the existing flag into the scheduler: track fix status on every poll, and block scheduling a new transmit entry until a fix has been acquired at least once. Mid-repeat-sequence continuation (tier 1) runs earlier in the function and is unaffected, so an in-progress transmission is never aborted — only new scheduling is gated.

## Test plan
- [x] Build-verified via the Docker toolchain (`rs41ng_compiler`) with `radio_tx_wait_for_gps_lock` both `true` and `false` — both compile clean, no warnings.
- [ ] Not flashed/tested on hardware.