### PR TITLE
Never send 0,0 in APRS position/weather reports

### DIFF
--- a/src/codecs/aprs/aprs.c
+++ b/src/codecs/aprs/aprs.c
@@ -24,3 +24,9 @@ void aprs_generate_timestamp(char *timestamp, size_t length, telemetry_data *dat
 {
     snprintf(timestamp, length, "/%02d%02d%02dz", data->gps.hours, data->gps.minutes, data->gps.seconds);
 }
+
+size_t aprs_generate_status(uint8_t *payload, size_t length, char *comment)
+{
+    aprs_packet_counter++;
+    return snprintf((char *) payload, length, ">%s", comment);
+}

--- a/src/codecs/aprs/aprs.h
+++ b/src/codecs/aprs/aprs.h
@@ -9,6 +9,7 @@
 
 void convert_degrees_to_dmh(long x, int16_t *degrees, uint8_t *minutes, uint8_t *h_minutes);
 void aprs_generate_timestamp(char *timestamp, size_t length, telemetry_data *data);
+size_t aprs_generate_status(uint8_t *payload, size_t length, char *comment);
 
 extern volatile uint16_t aprs_packet_counter;
 

--- a/src/radio.c
+++ b/src/radio.c
@@ -1146,10 +1146,20 @@ static radio_transmit_entry *radio_find_ready_entry()
         return radio_current_transmit_entry;
     }
 
-    // Tier 2: scan time-synced entries for matching window
     gps_data gps;
     gps_driver_get_current_gps_data(&gps);
 
+#if RADIO_TX_WAIT_FOR_GPS_LOCK
+    if (GPS_HAS_FIX(gps)) {
+        gps_fix_ever_acquired = true;
+    }
+
+    if (!gps_fix_ever_acquired) {
+        return NULL;
+    }
+#endif
+
+    // Tier 2: scan time-synced entries for matching window
     if (gps.updated) {
         uint32_t time_millis = gps.time_of_week_millis - (gps_time_leap_seconds * 1000);
 

--- a/src/radio.c
+++ b/src/radio.c
@@ -633,9 +633,8 @@ uint32_t precalculated_pwm_periods[FSK_TONE_COUNT_MAX];
 
 static volatile uint32_t start_tick = 0, end_tick = 0;
 
-#if RADIO_TX_WAIT_FOR_GPS_LOCK
 static bool gps_fix_ever_acquired = false;
-#endif
+static gps_data gps_last_known_fix;
 
 telemetry_data current_telemetry_data;
 
@@ -1149,11 +1148,12 @@ static radio_transmit_entry *radio_find_ready_entry()
     gps_data gps;
     gps_driver_get_current_gps_data(&gps);
 
-#if RADIO_TX_WAIT_FOR_GPS_LOCK
     if (GPS_HAS_FIX(gps)) {
         gps_fix_ever_acquired = true;
+        gps_last_known_fix = gps;
     }
 
+#if RADIO_TX_WAIT_FOR_GPS_LOCK
     if (!gps_fix_ever_acquired) {
         return NULL;
     }
@@ -1197,6 +1197,16 @@ static radio_transmit_entry *radio_find_ready_entry()
     }
 
     return NULL;
+}
+
+// Fills *out with the live or last-known fix; false if no fix has ever been acquired.
+bool radio_gps_get_position(gps_data *out)
+{
+    if (!gps_fix_ever_acquired) {
+        return false;
+    }
+    *out = gps_last_known_fix;
+    return true;
 }
 
 void radio_handle_main_loop()

--- a/src/radio.h
+++ b/src/radio.h
@@ -1,9 +1,14 @@
 #ifndef __RADIO_H
 #define __RADIO_H
 
+#include <stdbool.h>
+
+#include "gps.h"
+
 void radio_init();
 void radio_handle_timer_tick();
 void radio_handle_data_timer_tick();
 void radio_handle_main_loop();
+bool radio_gps_get_position(gps_data *out);
 
 #endif

--- a/src/radio_payload_aprs_position.c
+++ b/src/radio_payload_aprs_position.c
@@ -1,19 +1,28 @@
 #include <stdint.h>
 
 #include "codecs/ax25/ax25.h"
+#include "codecs/aprs/aprs.h"
 #include "codecs/aprs/aprs_position.h"
 #include "codecs/aprs_9600/aprs_9600.h"
 #include "config.h"
 #include "telemetry.h"
 #include "log.h"
+#include "radio.h"
 #include "radio_payload_aprs_position.h"
 
 uint16_t radio_aprs_position_encode(uint8_t *payload, uint16_t length, telemetry_data *telemetry_data, char *message)
 {
     uint8_t aprs_packet[RADIO_APRS_PAYLOAD_MAX_LENGTH];
 
-    aprs_generate_position(aprs_packet, sizeof(aprs_packet), telemetry_data,
-            APRS_SYMBOL_TABLE, APRS_SYMBOL, false, message);
+    gps_data gps;
+    if (radio_gps_get_position(&gps)) {
+        struct _telemetry_data local_data = *telemetry_data;
+        local_data.gps = gps;
+        aprs_generate_position(aprs_packet, sizeof(aprs_packet), &local_data,
+                APRS_SYMBOL_TABLE, APRS_SYMBOL, false, message);
+    } else {
+        aprs_generate_status(aprs_packet, sizeof(aprs_packet), message);
+    }
 
     log_debug("APRS packet: %s\n", aprs_packet);
 
@@ -30,8 +39,15 @@ uint16_t radio_aprs_9600_position_encode(uint8_t *payload, uint16_t length, tele
     uint8_t aprs_packet[128];
     uint8_t ax25_frame[128];
 
-    aprs_generate_position(aprs_packet, sizeof(aprs_packet), telemetry_data,
-            APRS_SYMBOL_TABLE, APRS_SYMBOL, false, message);
+    gps_data gps;
+    if (radio_gps_get_position(&gps)) {
+        struct _telemetry_data local_data = *telemetry_data;
+        local_data.gps = gps;
+        aprs_generate_position(aprs_packet, sizeof(aprs_packet), &local_data,
+                APRS_SYMBOL_TABLE, APRS_SYMBOL, false, message);
+    } else {
+        aprs_generate_status(aprs_packet, sizeof(aprs_packet), message);
+    }
 
     log_debug("APRS packet: %s\n", aprs_packet);
 

--- a/src/radio_payload_aprs_weather.c
+++ b/src/radio_payload_aprs_weather.c
@@ -1,17 +1,26 @@
 #include <stdint.h>
 
 #include "codecs/ax25/ax25.h"
+#include "codecs/aprs/aprs.h"
 #include "codecs/aprs/aprs_weather.h"
 #include "config.h"
 #include "telemetry.h"
 #include "log.h"
+#include "radio.h"
 #include "radio_payload_aprs_weather.h"
 
 uint16_t radio_aprs_weather_report_encode(uint8_t *payload, uint16_t length, telemetry_data *telemetry_data, char *message)
 {
     uint8_t aprs_packet[RADIO_APRS_PAYLOAD_MAX_LENGTH];
 
-    aprs_generate_weather_report(aprs_packet, sizeof(aprs_packet), telemetry_data,true, message);
+    gps_data gps;
+    if (radio_gps_get_position(&gps)) {
+        struct _telemetry_data local_data = *telemetry_data;
+        local_data.gps = gps;
+        aprs_generate_weather_report(aprs_packet, sizeof(aprs_packet), &local_data, true, message);
+    } else {
+        aprs_generate_status(aprs_packet, sizeof(aprs_packet), message);
+    }
 
     log_debug("APRS packet: %s\n", aprs_packet);
 


### PR DESCRIPTION
Depends on #134 — branched from it, so this PR's diff also shows PR #134's commit until that one merges.

## Summary
- `telemetry_collect()` zeroes `gps.lat/lon/altitude/speed/heading/climb` whenever there's no current GPS fix, even though both GPS drivers (`ubxm10050`, `ubxg6010`) write these fields from every PVT message unconditionally and would otherwise retain a graceful last estimate. APRS position and weather reports encoded that zeroed data directly, so a sonde transmitting before its first fix — or after briefly losing one — sent a literal 0,0 position.
- Caches the last-known-good fix in `radio.c`, reusing the polling loop from #134 that already tracks whether a fix has ever been acquired. Adds `radio_gps_get_position()`, returning the live-or-last-known fix, or `false` if no fix has ever been acquired.
- Wires it into all three APRS encoders (1200 baud, 9600 baud, weather): substitute the cached fix when the current reading has no lock, fall back to a position-less APRS status report (`>` data type indicator) when no fix has ever been acquired. Detection is fix-status-based throughout (`GPS_HAS_FIX()`), never a lat/lon value comparison — a real position at 0,0 still transmits normally.
- Scoped to APRS only — CATS, Horus, and `telemetry.c`'s own zero-out are unchanged, since they're shared by protocols outside this scope.

## Test plan
- [x] Build-verified via the Docker toolchain — compiles clean, no warnings.
- [ ] Not flashed/tested on hardware.